### PR TITLE
fix(output): using new GitHub Actions outputs method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Check-version test1
+        id: test1
+        uses: ./
+        with:
+          path: tests
+
+      - run: |
+          echo "name: ${{ steps.test1.outputs.name }}"
+          echo "version: ${{ steps.test1.outputs.version }}"
+          echo "release: ${{ steps.test1.outputs.release }}"
+
+      - name: Change file
+        run: echo "FAKE" >> tests/index.js
+
+      - name: Check-version test2
+        id: test2
+        uses: ./
+        with:
+          path: tests
+
+      - run: |
+          echo "name: ${{ steps.test2.outputs.name }}"
+          echo "version: ${{ steps.test2.outputs.version }}"
+          echo "release: ${{ steps.test2.outputs.release }}"

--- a/main.js
+++ b/main.js
@@ -136,6 +136,6 @@ const release = INPUT_FORMAT.replace(/\{pkg\}/gi, head.name)
   .replace(/\{pr_number\}/gi, event.pull_request.number);
 
 // Set the action output values (name, version, release)
-console.log(`::set-output name=name::${head.name}`);
-console.log(`::set-output name=version::${head.version}`);
-console.log(`::set-output name=release::${release}`);
+console.log(`echo "name=${head.name}" >> $GITHUB_OUTPUT`)
+console.log(`echo "version=${head.version}" >> $GITHUB_OUTPUT`)
+console.log(`echo "release=${release}" >> $GITHUB_OUTPUT`)

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "check-version-test",
+  "version": "0.0.0",
+  "description": "Project to test this GitHub Action",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
GitHub post and docs:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions\#setting-an-output-parameter